### PR TITLE
Update scam-urls.txt

### DIFF
--- a/scam-urls.txt
+++ b/scam-urls.txt
@@ -1755,6 +1755,7 @@ deshevil.xyz
 detectbots.click
 detectspam.click
 detterdiscord.net
+deutschepost-zollgebühren.de
 dev-discord.com
 dev.fosscord.com
 devdiscord.com
@@ -23868,6 +23869,7 @@ xgreen-exchange.com
 xgreen-trade.com
 xiaobaixitong.com
 xiomoinuyt03.z11.web.core.windows.net
+xn--deutschepost-zollgebhren-ftc.de
 xn--discrd-zxa.com
 xn--disordapp-s3a.com
 xn--me6-lra.xyz


### PR DESCRIPTION
I received this SMS with a link to the website: https://deutschepost-zollgebühren.de

There are a few add things about it. Why should German postal service send SMS from UK? And why in English? 🤔plus the website is empty. 🥹