### PR TITLE
Removal of incorrect domain entries

### DIFF
--- a/pihole-phishing-adlist.txt
+++ b/pihole-phishing-adlist.txt
@@ -9625,7 +9625,6 @@
 0.0.0.0 gg-matches.com
 0.0.0.0 gg-nitro.com
 0.0.0.0 gg.gg
-0.0.0.0 gg.gg/win-nitro
 0.0.0.0 ggboom.ru
 0.0.0.0 ggcscase.com
 0.0.0.0 ggcstrade.com
@@ -14458,7 +14457,6 @@
 0.0.0.0 ratnet.od.ua
 0.0.0.0 raydiumswap.com
 0.0.0.0 razblox.com
-0.0.0.0 rb.gy/k4vzy
 0.0.0.0 rblx-hub.org
 0.0.0.0 rblx.trade
 0.0.0.0 rblxcopy.com

--- a/scam-urls.txt
+++ b/scam-urls.txt
@@ -9609,7 +9609,6 @@ gg-captcha.cc
 gg-matches.com
 gg-nitro.com
 gg.gg
-gg.gg/win-nitro
 ggboom.ru
 ggcscase.com
 ggcstrade.com
@@ -14442,7 +14441,6 @@ ratingsbot.com
 ratnet.od.ua
 raydiumswap.com
 razblox.com
-rb.gy/k4vzy
 rblx-hub.org
 rblx.trade
 rblxcopy.com


### PR DESCRIPTION
Hi there! In this pull request, I've removed incorrect domain entries.

```
  [i] Target: https://blocklist.sefinek.net/generated/0.0.0.0/forks/Dogino.Discord-Phishing-URLs-phishing.txt
  [✓] Status: No changes detected
  [✓] Parsed 29163 exact domains and 0 ABP-style domains (blocking, ignored 2 non-domain entries)
      Sample of non-domain entries:
        - gg.gg/win-nitro
        - rb.gy/k4vzy


  [i] Target: https://blocklist.sefinek.net/generated/0.0.0.0/forks/Dogino.Discord-Phishing-URLs-scam.txt
  [✓] Status: No changes detected
  [✓] Parsed 29154 exact domains and 0 ABP-style domains (blocking, ignored 2 non-domain entries)
      Sample of non-domain entries:
        - gg.gg/win-nitro
        - rb.gy/k4vzy
```

![](https://cdn.discordapp.com/emojis/789914898808176723.webp)