### PR TITLE
Remove discord.builders from adlists and scam urls

### DIFF
--- a/pihole-phishing-adlist.txt
+++ b/pihole-phishing-adlist.txt
@@ -1,6 +1,6 @@
 # Title: AntiPhishingDiscordSteam
 # Description: This list blocks known domains used in the VOIP application Discord by scammers. Adding this list to your Pi-Hole blocklist will prevent those domains from loading.
-# Last modified: Thu, 24 Oct 2024, 11:19 UTC+02
+# Last modified: Thu, 25 Apr 2025, 20:47 UTC
 # Origin: https://github.com/Dogino/Discord-Phishing-URLs
 
 0.0.0.0 cord.gifts

--- a/pihole-phishing-adlist.txt
+++ b/pihole-phishing-adlist.txt
@@ -6742,7 +6742,6 @@
 0.0.0.0 discord.broker
 0.0.0.0 discord.bug-form.com
 0.0.0.0 discord.build
-0.0.0.0 discord.builders
 0.0.0.0 discord.buzz
 0.0.0.0 discord.camera
 0.0.0.0 discord.capital

--- a/scam-urls.txt
+++ b/scam-urls.txt
@@ -6726,7 +6726,6 @@ discord.boutique
 discord.broker
 discord.bug-form.com
 discord.build
-discord.builders
 discord.buzz
 discord.camera
 discord.capital


### PR DESCRIPTION
Hello!

https://discord.builders is no longer used to scam, but is now a helpful website that hosts the code in this repository https://github.com/StartITBot/discord.builders

Would be nice to get it removed from the list if possible :)